### PR TITLE
新增：easyswoole/session库依赖

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": ">=7.1.0",
         "ext-swoole":">=4.0",
         "easyswoole/spl": "^1.0",
+        "easyswoole/session": "^2.0",
         "easyswoole/component": "^2.1",
         "nikic/fast-route": "^1.3",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
全局变量注册可同时注册session，但未引用easyswoole/session库